### PR TITLE
clearer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,42 +2,24 @@
 [![Build Status](https://travis-ci.org/haskell/ghcup.svg?branch=master)](https://travis-ci.org/haskell/ghcup)
 [![license](https://img.shields.io/github/license/haskell/ghcup.svg)](COPYING)
 
-# GHC up
+[`cabal-install`](https://hackage.haskell.org/package/cabal-install) manages Haskell library dependencies and can select a specific version of `ghc` (see [`with-compiler`](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)). However, `cabal` will fail if the required version is not available and many operating systems do not offer a way to install specific versions of `ghc`.
 
-Installs a specified GHC version into `~/.ghcup/ghc/<ver>`,
-and places `ghc-<ver>` etc. symlinks in `~/.ghcup/bin/`.
-Additionally allows to manage currently selected ghc
-via unversioned symlinks.
+`ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux, and can also bootstrap a fresh Haskell developer environment from scratch.
 
-This uses precompiled GHC binaries that have been
-compiled on fedora/debian by
-[upstream GHC](https://www.haskell.org/ghc/download_ghc_8_6_1.html#binaries).
+Inspired by [rustup](https://github.com/rust-lang-nursery/rustup.rs), [pyenv](https://github.com/pyenv/pyenv) and [jenv](http://www.jenv.be).
 
-Alternatively, you can also tell it to compile from source (note that this might
-fail due to missing requirements).
-
-In addition this script can also install `cabal-install`.
+*OS X users may prefer [futurice](https://haskell.futurice.com/) and Ubuntu users may prefer [hvr's ppa](https://launchpad.net/~hvr/+archive/ubuntu/ghc).*
 
 **Note: this project is in early stage and may not work on all distributions yet!**
 
 ## Table of Contents
 
-   * [Why](#why)
    * [Installation](#installation)
+   * [How](#how)
    * [Usage](#usage)
    * [Contributing](#contributing)
    * [TODO](#todo)
    * [Known problems](#known-problems)
-
-## Why
-
-`cabal new-*` manages your haskell packages, but not GHC versions, since
-it follows the unix philosophy. Unfortunately system GHC versions
-are often either outdated or cannot be installed in parallel
-with proper symlink management on many distros. This tool
-tries to fill that gap and be fairly distro-agnostic.
-
-Inspired by [rustup](https://github.com/rust-lang-nursery/rustup.rs).
 
 ## Installation
 
@@ -57,6 +39,21 @@ Then adjust your `PATH` in `~/.bashrc` (or similar, depending on your shell) lik
 export PATH="$HOME/.cabal/bin:$HOME/.ghcup/bin:$HOME/.local/bin:$PATH"
 ```
 
+## How
+
+Installs a specified GHC version into `~/.ghcup/ghc/<ver>`,
+and places `ghc-<ver>` etc. symlinks in `~/.ghcup/bin/`.
+Additionally allows to manage currently selected ghc
+via unversioned symlinks.
+
+This uses precompiled GHC binaries that have been
+compiled on fedora/debian by
+[upstream GHC](https://www.haskell.org/ghc/download_ghc_8_6_1.html#binaries).
+
+Alternatively, you can also tell it to compile from source (note that this might
+fail due to missing requirements).
+
+In addition this script can also install `cabal-install`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/haskell/ghcup.svg?branch=master)](https://travis-ci.org/haskell/ghcup)
 [![license](https://img.shields.io/github/license/haskell/ghcup.svg)](COPYING)
 
-Although [`cabal-install`](https://hackage.haskell.org/package/cabal-install) manages Haskell library dependencies and can select a specific version of `ghc` (see [`with-compiler`](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)), it will fail if the required version of `ghc` is not available. Unfortunately, many operating systems do not offer a way to install specific versions of `ghc`.
+Although [`cabal-install`](https://hackage.haskell.org/package/cabal-install) automatically installs Haskell library dependencies, and selects a specific version of `ghc` (see [`with-compiler`](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)). However, `cabal-install` will fail if the required version of `ghc` is not available. Unfortunately, many operating systems do not offer a way to install specific versions of `ghc`.
 
 `ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux, and can also bootstrap a fresh Haskell developer environment from scratch.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/haskell/ghcup.svg?branch=master)](https://travis-ci.org/haskell/ghcup)
 [![license](https://img.shields.io/github/license/haskell/ghcup.svg)](COPYING)
 
-[`cabal-install`](https://hackage.haskell.org/package/cabal-install) follows the UNIX philosophy of [do one thing and do it well](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well): it builds your project by managing your dependencies. However, `cabal-install` does not download `ghc` if one is needed, although, it can demand that [a specific version](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)  of `ghc` is available. Unfortunately, many operating systems do not offer a way to install multiple versions of `ghc`.
+[`cabal-install`](https://hackage.haskell.org/package/cabal-install) follows the UNIX philosophy of [do one thing and do it well](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well): it builds your project by managing your dependencies. However, `cabal-install` does not download `ghc` if one is needed, although it can demand that [a specific version](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)  of `ghc` is available. Unfortunately, many operating systems do not offer a way to install multiple versions of `ghc`.
 
 `ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux, and can also bootstrap a fresh Haskell developer environment from scratch.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/haskell/ghcup.svg?branch=master)](https://travis-ci.org/haskell/ghcup)
 [![license](https://img.shields.io/github/license/haskell/ghcup.svg)](COPYING)
 
-[`cabal-install`](https://hackage.haskell.org/package/cabal-install) manages Haskell library dependencies and can select a specific version of `ghc` (see [`with-compiler`](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)). However, `cabal` will fail if the required version is not available and many operating systems do not offer a way to install specific versions of `ghc`.
+Although [`cabal-install`](https://hackage.haskell.org/package/cabal-install) manages Haskell library dependencies and can select a specific version of `ghc` (see [`with-compiler`](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)), it will fail if the required version of `ghc` is not available. Unfortunately, many operating systems do not offer a way to install specific versions of `ghc`.
 
 `ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux, and can also bootstrap a fresh Haskell developer environment from scratch.
 
@@ -15,10 +15,8 @@ Inspired by [rustup](https://github.com/rust-lang-nursery/rustup.rs), [pyenv](ht
 ## Table of Contents
 
    * [Installation](#installation)
-   * [How](#how)
    * [Usage](#usage)
    * [Contributing](#contributing)
-   * [TODO](#todo)
    * [Known problems](#known-problems)
 
 ## Installation
@@ -39,22 +37,6 @@ Then adjust your `PATH` in `~/.bashrc` (or similar, depending on your shell) lik
 export PATH="$HOME/.cabal/bin:$HOME/.ghcup/bin:$HOME/.local/bin:$PATH"
 ```
 
-## How
-
-Installs a specified GHC version into `~/.ghcup/ghc/<ver>`,
-and places `ghc-<ver>` etc. symlinks in `~/.ghcup/bin/`.
-Additionally allows to manage currently selected ghc
-via unversioned symlinks.
-
-This uses precompiled GHC binaries that have been
-compiled on fedora/debian by
-[upstream GHC](https://www.haskell.org/ghc/download_ghc_8_6_1.html#binaries).
-
-Alternatively, you can also tell it to compile from source (note that this might
-fail due to missing requirements).
-
-In addition this script can also install `cabal-install`.
-
 ## Usage
 
 See `ghcup --help`.
@@ -66,15 +48,11 @@ See `ghcup --help`.
 * use [shellcheck](https://github.com/koalaman/shellcheck) and `checkbashisms.pl` from [debian devscripts](http://http.debian.net/debian/pool/main/d/devscripts/devscripts_2.18.4.tar.xz)
 * whitespaces, no tabs
 
-## TODO
-
-- [ ] FreeBSD support ([#4](https://github.com/haskell/ghcup/issues/4))
-- [ ] Make fetching tarballs more robust ([#5](https://github.com/haskell/ghcup/issues/5))
-- [x] More code documentation
-- [x] Allow to compile from source ([#2](https://github.com/haskell/ghcup/issues/2))
-- [x] Allow to install cabal-install as well ([#3](https://github.com/haskell/ghcup/issues/3))
-
 ## Known problems
+
+### Limited distributions supported
+
+Currently only GNU/Linux distributions compatible with the [upstream GHC](https://www.haskell.org/ghc/download_ghc_8_6_1.html#binaries) binaries (built on Fedora) are supported.
 
 ### Precompiled binaries
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/haskell/ghcup.svg?branch=master)](https://travis-ci.org/haskell/ghcup)
 [![license](https://img.shields.io/github/license/haskell/ghcup.svg)](COPYING)
 
-Although [`cabal-install`](https://hackage.haskell.org/package/cabal-install) automatically installs Haskell library dependencies, and selects a specific version of `ghc` (see [`with-compiler`](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)). However, `cabal-install` will fail if the required version of `ghc` is not available. Unfortunately, many operating systems do not offer a way to install specific versions of `ghc`.
+[`cabal-install`](https://hackage.haskell.org/package/cabal-install) follows the UNIX philosophy of [do one thing and do it well](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well): it builds your project and downloads your dependencies. However, `cabal-install` does not download `ghc` if one is needed ([it can demand that a specific version of `ghc` is available](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)). Unfortunately, many operating systems do not offer a way to install multiple versions of `ghc`.
 
 `ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux, and can also bootstrap a fresh Haskell developer environment from scratch.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/haskell/ghcup.svg?branch=master)](https://travis-ci.org/haskell/ghcup)
 [![license](https://img.shields.io/github/license/haskell/ghcup.svg)](COPYING)
 
-[`cabal-install`](https://hackage.haskell.org/package/cabal-install) follows the UNIX philosophy of [do one thing and do it well](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well): it builds your project and downloads your dependencies. However, `cabal-install` does not download `ghc` if one is needed ([it can demand that a specific version of `ghc` is available](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)). Unfortunately, many operating systems do not offer a way to install multiple versions of `ghc`.
+[`cabal-install`](https://hackage.haskell.org/package/cabal-install) follows the UNIX philosophy of [do one thing and do it well](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well): it builds your project by managing your dependencies. However, `cabal-install` does not download `ghc` if one is needed, although, it can demand that [a specific version](https://cabal.readthedocs.io/en/latest/nix-local-build.html#cfg-flag---with-compiler)  of `ghc` is available. Unfortunately, many operating systems do not offer a way to install multiple versions of `ghc`.
 
 `ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux, and can also bootstrap a fresh Haskell developer environment from scratch.
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Inspired by [rustup](https://github.com/rust-lang-nursery/rustup.rs), [pyenv](ht
 
 *OS X users may prefer [futurice](https://haskell.futurice.com/) and Ubuntu users may prefer [hvr's ppa](https://launchpad.net/~hvr/+archive/ubuntu/ghc).*
 
-**Note: this project is in early stage and may not work on all distributions yet!**
-
 ## Table of Contents
 
    * [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See `ghcup --help`.
 
 ### Limited distributions supported
 
-Currently only GNU/Linux distributions compatible with the [upstream GHC](https://www.haskell.org/ghc/download_ghc_8_6_1.html#binaries) binaries (built on Fedora) are supported.
+Currently only GNU/Linux distributions compatible with the [upstream GHC](https://www.haskell.org/ghc/download_ghc_8_6_1.html#binaries) binaries are supported.
 
 ### Precompiled binaries
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux, and can also bootstrap a fresh Haskell developer environment from scratch.
 
-Inspired by [rustup](https://github.com/rust-lang-nursery/rustup.rs), [pyenv](https://github.com/pyenv/pyenv) and [jenv](http://www.jenv.be).
+Similar in scope to [rustup](https://github.com/rust-lang-nursery/rustup.rs), [pyenv](https://github.com/pyenv/pyenv) and [jenv](http://www.jenv.be).
 
 *OS X users may prefer [futurice](https://haskell.futurice.com/) and Ubuntu users may prefer [hvr's ppa](https://launchpad.net/~hvr/+archive/ubuntu/ghc).*
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Inspired by [rustup](https://github.com/rust-lang-nursery/rustup.rs), [pyenv](ht
 
    * [Installation](#installation)
    * [Usage](#usage)
+   * [How](#how)
    * [Contributing](#contributing)
    * [Known problems](#known-problems)
 
@@ -38,6 +39,18 @@ export PATH="$HOME/.cabal/bin:$HOME/.ghcup/bin:$HOME/.local/bin:$PATH"
 ## Usage
 
 See `ghcup --help`.
+
+## How
+
+Installs a specified GHC version into `~/.ghcup/ghc/<ver>`, and places `ghc-<ver>` symlinks in `~/.ghcup/bin/`.
+
+Optionally, an unversioned `ghc` link can point to a default version of your choice.
+
+This uses precompiled GHC binaries that have been compiled on fedora/debian by [upstream GHC](https://www.haskell.org/ghc/download_ghc_8_6_1.html#binaries).
+
+Alternatively, you can also tell it to compile from source (note that this might fail due to missing requirements).
+
+In addition this script can also install `cabal-install`.
 
 ## Contributing
 


### PR DESCRIPTION
I thought that the intro could do with a little bit of editing to make it more obvious what this script does, what it doesn't do, and get straight to the installation. Plus more links out to `cabal` documentation and features.

I also removed some redundancy (including the `TODO` section, which is already out of date with the issue tracker)