### PR TITLE
Drop unused fast_finish: true from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,3 @@ addons:
 # TODO: also run checkbashisms.pl (currently two instances of non-compliance)
 script:
  - ./.travis.sh
-
-matrix:
-  fast_finish: true


### PR DESCRIPTION
"fast_finish: true" is only effective when you have jobs in your
build matrix that you allow to fail, which isn't the case here.

https://blog.travis-ci.com/2013-11-27-fast-finishing-builds