### PR TITLE
Set ghc-8.6.3 as the recommended version

### DIFF
--- a/.available-versions
+++ b/.available-versions
@@ -12,10 +12,10 @@
 ghc              8.0.2
 ghc              8.2.2
 ghc              8.4.3
-ghc              8.4.4    recommended
+ghc              8.4.4
 ghc              8.6.1    bad
 ghc              8.6.2
-ghc              8.6.3    latest
+ghc              8.6.3    latest,recommended
 cabal-install    2.2.0.0
 cabal-install    2.4.0.0
 cabal-install    2.4.1.0  latest,recommended


### PR DESCRIPTION
It seems to work well with current ecosystem and stackage
has just introduced 8.6.3 as part of lts-13.1:
  https://www.stackage.org/lts-13.1