### PR TITLE
Add GHC 8.6.4

### DIFF
--- a/.available-versions
+++ b/.available-versions
@@ -15,7 +15,8 @@ ghc              8.4.3
 ghc              8.4.4
 ghc              8.6.1    bad
 ghc              8.6.2
-ghc              8.6.3    latest,recommended
+ghc              8.6.3    recommended
+ghc              8.6.4    latest
 cabal-install    2.2.0.0
 cabal-install    2.4.0.0
 cabal-install    2.4.1.0  latest,recommended

--- a/.download-urls
+++ b/.download-urls
@@ -63,6 +63,12 @@ ghc 8.6.3   x86_64  centos=7,centos,amazonlinux     https://downloads.haskell.or
 ghc 8.6.3   x86_64  darwin                          https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-apple-darwin.tar.xz
 ghc 8.6.3   x86_64  freebsd=11                      https://downloads.haskell.org/~ghc/8.6.3/ghc-8.6.3-x86_64-portbld-freebsd.tar.xz
 
+ghc 8.6.4   i386    debian=9,debian,ubuntu,unknown  https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-i386-deb9-linux.tar.xz
+ghc 8.6.4   x86_64  debian=8                        https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-deb8-linux.tar.xz
+ghc 8.6.4   x86_64  debian=9,debian,ubuntu          https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-deb9-linux.tar.xz
+ghc 8.6.4   x86_64  fedora=27,fedora,unknown        https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-fedora27-linux.tar.xz
+ghc 8.6.4   x86_64  darwin                          https://downloads.haskell.org/~ghc/8.6.4/ghc-8.6.4-x86_64-apple-darwin.tar.xz
+
 
 
 cabal-install   2.2.0.0     i386    unknown         https://downloads.haskell.org/~cabal/cabal-install-2.2.0.0/cabal-install-2.2.0.0-i386-unknown-linux.tar.gz


### PR DESCRIPTION
Added downloads available from https://downloads.haskell.org/~ghc/8.6.4/
as at the time of commit.

Have not made this recommended yet until common tools and libs are all
confirmed to work fine.