### PR TITLE
Prefer "macOS" over "Mac OS X"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/haskell/ghcup.svg?branch=master)](https://travis-ci.org/haskell/ghcup)
 [![license](https://img.shields.io/github/license/haskell/ghcup.svg)](COPYING)
 
-`ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux as well as MacOS (aka Darwin), and can also bootstrap a fresh Haskell developer environment from scratch.
+`ghcup` makes it easy to install specific versions of `ghc` on GNU/Linux as well as macOS (aka Darwin), and can also bootstrap a fresh Haskell developer environment from scratch.
 It follows the unix UNIX philosophy of [do one thing and do it well](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well).
 
 Similar in scope to [rustup](https://github.com/rust-lang-nursery/rustup.rs), [pyenv](https://github.com/pyenv/pyenv) and [jenv](http://www.jenv.be).

--- a/www/index.html
+++ b/www/index.html
@@ -33,7 +33,7 @@
       <div id="platform-instructions-mac" class="instructions" style="display: none;">
         <p>Run the following in your terminal, then follow the onscreen instructions.</p>
         <pre>curl https://get-ghcup.haskell.org -sSf | sh</pre>
-        <p class="other-help">If you don't like curl | sh, see <a href="https://github.com/haskell/ghcup#manual-install">other installation methods</a>.<br/>You appear to be running Mac OS X. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
+        <p class="other-help">If you don't like curl | sh, see <a href="https://github.com/haskell/ghcup#manual-install">other installation methods</a>.<br/>You appear to be running macOS. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
       </div>
 
       <div id="platform-instructions-freebsd" class="instructions" style="display: none;">
@@ -62,7 +62,7 @@
         <!-- unrecognized platform: ask for help -->
         <p>I don't recognize your platform.</p>
         <p>
-          ghcup runs on Linux, Mac OS X and FreeBSD. If
+          ghcup runs on Linux, macOS and FreeBSD. If
           you are on one of these platforms and are seeing this then please
           <a href="https://github.com/haskell/ghcup/issues">report an issue</a>,
           along with the following values:
@@ -77,7 +77,7 @@
 
         <!-- duplicate the default cross-platform instructions -->
         <div>
-          <p>If you are running Linux, Mac OS X or FreeBSD,<br/>run the following in your terminal, then follow the onscreen instructions.</p>
+          <p>If you are running Linux, macOS or FreeBSD,<br/>run the following in your terminal, then follow the onscreen instructions.</p>
           <pre>curl https://get-ghcup.haskell.org -sSf | sh</pre>
           <p class="other-help">If you don't like curl | sh, see <a href="https://github.com/haskell/ghcup#manual-install">other installation methods</a>.</p>
         </div>
@@ -95,7 +95,7 @@
 
       <div id="platform-instructions-default" class="instructions">
         <div>
-          <p>To install Haskell, if you are running Linux, Mac OS X or FreeBSD,<br/>run the following
+          <p>To install Haskell, if you are running Linux, macOS or FreeBSD,<br/>run the following
           in your terminal, then follow the onscreen instructions.</p>
           <pre>curl https://get-ghcup.haskell.org -sSf | sh</pre>
           <p class="other-help">If you don't like curl | sh, see <a href="https://github.com/haskell/ghcup#manual-install">other installation methods</a>.</p>
@@ -140,7 +140,7 @@
 
       <div id="platform-instructions-default" class="instructions">
         <div>
-          <p>To install Haskell, if you are running Linux, Mac OS X or FreeBSD,<br/>run the following
+          <p>To install Haskell, if you are running Linux, macOS or FreeBSD,<br/>run the following
           in your terminal, then follow the onscreen instructions.</p>
           <pre>curl https://get-ghcup.haskell.org -sSf | sh</pre>
           <p class="other-help">If you don't like curl | sh, see <a href="https://github.com/haskell/ghcup#manual-install">other installation methods</a>.</p>


### PR DESCRIPTION
(Apple rebranded Mac OS X to OS X in 2012, and then to macOS in 2016.)